### PR TITLE
fix/kakaoAPI

### DIFF
--- a/components/locationCategory/locationCategoryItem.tsx
+++ b/components/locationCategory/locationCategoryItem.tsx
@@ -13,6 +13,7 @@ const locationCategoryItem = (props: Props) => {
   const setRegion = locationState((state) => state.setRegion)
   const setCity = locationState((state) => state.setCity)
   const setIdx = locationState((state) => state.setIdx)
+  const setService = locationState((state) => state.setService)
   const region = locationState((state) => state.region)
 
   const locationItemLeftAnimation01 = useScrollFadeIn("left", 0.5, 0.1)
@@ -20,6 +21,8 @@ const locationCategoryItem = (props: Props) => {
     setIdx(props.idx)
     setRegion(props.locationName)
     setCity("")
+    setService("")
+
   };
   useEffect(()=>{
     console.log(region,"리전")

--- a/components/thirdSection.tsx
+++ b/components/thirdSection.tsx
@@ -5,7 +5,7 @@ import { SearchBoxInput } from "./nav";
 import { SearchBtn } from "../styles/globalStyle";
 import useScrollFadeIn from "../hooks/useScrollFadein";
 import LocationCategoryItem from "./locationCategory/locationCategoryItem";
-import { locationState } from "../state/store";
+import { kakaoMapState, locationState } from "../state/store";
 import CityLocationCategoryItem from "./locationCategory/cityLocationCategoryItem";
 import ServiceCategoryItem from "./locationCategory/serviceCategoryItem";
 import Loading from "./common/loading";
@@ -22,6 +22,9 @@ const ThirdSection = () => {
   const cityState = locationState((state) => state.city);
   const idxState = locationState((state) => state.idx);
   const serviceState = locationState((state) => state.service);
+  const markers = kakaoMapState((state) => state.markers)
+  const setMarkers = kakaoMapState((state) => state.setMarkers)
+  const resetMarkers = kakaoMapState((state) => state.resetMarkers)
 
   const [loading, setLoading] = useState<boolean>(false);
 
@@ -47,8 +50,6 @@ const ThirdSection = () => {
   const [map, setMap] = useState<any>()
   let infoWindow: any;
   let ps: any;
-  var markers: [] = [];
-
   const placesSearchCB = (data: any, status: any, pagination: any) => {
     if (status === window.kakao.maps.services.Status.OK) {
       // 정상적으로 검색이 완료됐으면
@@ -93,13 +94,17 @@ const ThirdSection = () => {
     }
   };
   const removeMarker = () => {
+    console.log("리무스 마커 함수 작동")
+    let copyMarkers = [...markers]
     for (let i = 0; i < markers.length; i++) {
-      markers[i]?.setMap(null);
+      console.log(markers[i],"마커 i번째")
+      copyMarkers[i].setMap(null);
     }
-    markers = [];
+    resetMarkers()
   };
 
   const addMarker = (position: any, idx: any, title?: any) => {
+    
     var imageSrc =
         "https://t1.daumcdn.net/localimg/localimages/07/mapapidoc/marker_number_blue.png", // 마커 이미지 url, 스프라이트 이미지를 씁니다
       imageSize = new window.kakao.maps.Size(36, 37), // 마커 이미지의 크기
@@ -117,9 +122,8 @@ const ThirdSection = () => {
       position: position, // 마커의 위치
       image: markerImage,
     });
-
     marker.setMap(map); // 지도 위에 마커를 표출합니다
-    markers?.push(marker); // 배열에 생성된 마커를 추가합니다
+    setMarkers(marker)
 
     return marker;
   };
@@ -221,10 +225,11 @@ const ThirdSection = () => {
       listStr = "";
 
     // 검색 결과 목록에 추가된 항목들을 제거합니다
+    removeMarker();
+
     removeAllChildNods(listEl);
 
     // 지도에 표시되고 있는 마커를 제거합니다
-    removeMarker();
 
     for (var i = 0; i < places.length; i++) {
       // 마커를 생성하고 지도에 표시합니다
@@ -308,6 +313,10 @@ const ThirdSection = () => {
   useEffect(()=>{
     console.log(map,"맵이다맵")
   },[map])
+
+  useEffect(()=>{
+  console.log(markers,"마커스")
+  },[markers])
   return (
     <>
       <Loading view={loading}></Loading>
@@ -446,10 +455,13 @@ const MapMenuWrap = styled.div`
   margin-left:10px;
   margin-top:10px;
   padding-bottom:10px;
-  width:30%;
+  width:250px;
   height:90%;
   overflow:scroll;
   z-index:1000;
+  @media screen and (max-width:768px){
+    width:200px;
+  }
 `
 
 const PageNation = styled.div`

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,7 +5,7 @@ import Nav from '../components/nav'
 function MyApp({ Component, pageProps }: AppProps) {
   return (
   <>
-    <title>개시원</title>
+    <title>팔자 좋은 개</title>
     <Nav></Nav>
     <Component {...pageProps} />
   </>

--- a/state/store.ts
+++ b/state/store.ts
@@ -1,37 +1,55 @@
 import create from "zustand";
 
 interface locationStateType {
-    idx: number;
-    setIdx: (idx: number) => void;
-    region: string;
-    setRegion: (region: string) => void;
-    city: string;
-    setCity: (city: string) => void;
-    county: string;
-    setCounty: (county: string) => void;
-    service: string;
-    setService: (serice: string) => void;
-  }
+  idx: number;
+  setIdx: (idx: number) => void;
+  region: string;
+  setRegion: (region: string) => void;
+  city: string;
+  setCity: (city: string) => void;
+  county: string;
+  setCounty: (county: string) => void;
+  service: string;
+  setService: (serice: string) => void;
+}
 
-  export const locationState = create<locationStateType>((set) => ({
-    idx: 0,
-    setIdx: (idx) => {
-      set( {idx} )
-    },
-    region: "",
-    setRegion: (region) => {
-      set({ region })
-    },
-    city: "",
-    setCity: (city) => {
-      set({ city })
-    },
-    county: "",
-    setCounty: (county) => {
-      set({ county })
-    },
-    service: "",
-    setService: (service) => {
-      set( { service } )
-    }
-  }));
+interface kakaoMapState {
+  markers: any[];
+  setMarkers: (obj: {}) => void;
+  removeMarkers: () => void;
+}
+
+export const locationState = create<locationStateType>((set) => ({
+  idx: 0,
+  setIdx: (idx) => {
+    set({ idx });
+  },
+  region: "",
+  setRegion: (region) => {
+    set({ region });
+  },
+  city: "",
+  setCity: (city) => {
+    set({ city });
+  },
+  county: "",
+  setCounty: (county) => {
+    set({ county });
+  },
+  service: "",
+  setService: (service) => {
+    set({ service });
+  },
+}));
+
+export const kakaoMapState = create<kakaoMapState>((set) => ({
+  markers: [],
+  setMarkers: (obj) => {
+    set((state) => ({
+      markers: [...state.markers, obj],
+    }));
+  },
+  resetMarkers: () => {
+    set({ markers: [] });
+  },
+}));


### PR DESCRIPTION
랜더링되면서 값이 빈배열로 계속 초기화되는 문제 발생으로 kakaoMapAPI가 제대로 작동하지 않음
검색 후 지도에 marker가 찍히고 다른 지역 검색 시 해당 marker가 사라져야 하는데 누적되어 있는 오류

전역 상태로 marker를 관리해서 페이지 페이지 랜더링 시에도 예상못한 작동을 방지